### PR TITLE
Added support for parallel Snap3D Generations

### DIFF
--- a/AI Playground/Assets/Scripts/Snap3DInteractable.ts
+++ b/AI Playground/Assets/Scripts/Snap3DInteractable.ts
@@ -41,6 +41,8 @@ export class Snap3DInteractable extends BaseScriptComponent {
 
   setImage(image: Texture) {
     this.img.enabled = true;
+    // Clone material to avoid replicating the preview image across instances
+    this.img.mainMaterial = this.img.mainMaterial.clone();
     this.img.mainPass.baseTex = image;
   }
 

--- a/AI Playground/Assets/Scripts/Snap3DInteractableFactory.ts
+++ b/AI Playground/Assets/Scripts/Snap3DInteractableFactory.ts
@@ -22,7 +22,6 @@ export class Snap3DInteractableFactory extends BaseScriptComponent {
   @input
   snap3DInteractablePrefab: ObjectPrefab;
 
-  private avaliableToRequest: boolean = true;
   private wcfmp = WorldCameraFinderProvider.getInstance();
 
   onAwake() {
@@ -39,11 +38,6 @@ export class Snap3DInteractableFactory extends BaseScriptComponent {
     overridePosition?: vec3
   ): Promise<string> {
     return new Promise((resolve, reject) => {
-      if (!this.avaliableToRequest) {
-        print("Already processing a request. Please wait.");
-        return;
-      }
-      this.avaliableToRequest = false;
       let outputObj = this.snap3DInteractablePrefab.instantiate(
         this.sceneObject
       );
@@ -75,7 +69,6 @@ export class Snap3DInteractableFactory extends BaseScriptComponent {
               assetOrError = assetOrError as Snap3DTypes.GltfAssetData;
               if (!this.refineMesh) {
                 snap3DInteractable.setModel(assetOrError.gltfAsset, true);
-                this.avaliableToRequest = true;
                 resolve("Successfully created mesh with prompt: " + input);
               } else {
                 snap3DInteractable.setModel(assetOrError.gltfAsset, false);
@@ -83,13 +76,11 @@ export class Snap3DInteractableFactory extends BaseScriptComponent {
             } else if (value === "refined_mesh") {
               assetOrError = assetOrError as Snap3DTypes.GltfAssetData;
               snap3DInteractable.setModel(assetOrError.gltfAsset, true);
-              this.avaliableToRequest = true;
               resolve("Successfully created mesh with prompt: " + input);
             } else if (value === "failed") {
               assetOrError = assetOrError as Snap3DTypes.ErrorData;
               print("Error: " + assetOrError.errorMsg);
               //snap3DInteractable.onFailure(assetOrError.errorMsg);
-              this.avaliableToRequest = true;
               reject("Failed to create mesh with prompt: " + input);
             }
           });
@@ -97,11 +88,10 @@ export class Snap3DInteractableFactory extends BaseScriptComponent {
         .catch((error) => {
           snap3DInteractable.onFailure(error);
           print("Error submitting task or getting status: " + error);
-          this.avaliableToRequest = true;
           reject("Failed to create mesh with prompt: " + input);
         });
     });
   }
 
-  private onTap() {}
+  private onTap() { }
 }


### PR DESCRIPTION
This PR resolves #8 and enables multiple Snap3D generations at the same time.

<img height="400" alt="TabTip_2311" src="https://github.com/user-attachments/assets/03356499-34af-4490-b1d1-bad43e6e83d3" />

<img height="400" alt="TabTip_2312" src="https://github.com/user-attachments/assets/173bff58-9fc6-4588-9390-1d5ee73fa45a" />


The only blocker was reusing the same material across instances of Snap3DInteractable prefab. The simple fix was to clone the material before assigning the image. Then simply remove the bool check of availableToRequest in Snap3DInteractableFactory.